### PR TITLE
feat: add template function to escape slack specific characters

### DIFF
--- a/templater/escape.go
+++ b/templater/escape.go
@@ -1,0 +1,21 @@
+package templater
+
+import "strings"
+
+func EscapeSlackText(text string) string {
+	escapedCharacters := map[string]string{
+		"&": "&amp;",
+		"<": "&lt;",
+		">": "&gt;",
+	}
+
+	// Since, maps in go are unordered, we need to maintain the
+	// the order in which we escape these characters. The '&'
+	// character must be escaped first since it is used in the
+	// escaped character representation.
+	for _, c := range []string{"&", "<", ">"} {
+		text = strings.ReplaceAll(text, c, escapedCharacters[c])
+	}
+
+	return text
+}

--- a/templater/escape_test.go
+++ b/templater/escape_test.go
@@ -1,0 +1,47 @@
+package templater
+
+import "testing"
+
+func TestEscapeSlackText(t *testing.T) {
+	type args struct {
+		text string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "escapes & to &amp;",
+			args: args{text: "&"},
+			want: "&amp;",
+		},
+		{
+			name: "escapes < to &lt;",
+			args: args{text: "<"},
+			want: "&lt;",
+		},
+		{
+			name: "escapes > to &gt;",
+			args: args{text: ">"},
+			want: "&gt;",
+		},
+		{
+			name: "escapes multiple special characters",
+			args: args{text: "ab&d<e>but&<z>"},
+			want: "ab&amp;d&lt;e&gt;but&amp;&lt;z&gt;",
+		},
+		{
+			name: "doesn't escape if no special characters are present",
+			args: args{text: "this.has:no'slack'special[chars]"},
+			want: "this.has:no'slack'special[chars]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EscapeSlackText(tt.args.text); got != tt.want {
+				t.Errorf("EscapeSlackText() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/templater/go.go
+++ b/templater/go.go
@@ -16,6 +16,7 @@ func (*Go) Execute(pattern string, params interface{}) ([]byte, error) {
 		"plural":           Plural,
 		"pluralWord":       PluralWord,
 		"truncateQuantity": TruncateQuantity,
+		"escapeSlackText":  EscapeSlackText,
 	}).Parse(pattern)
 
 	if err != nil {


### PR DESCRIPTION
The `&`, `<`, `>` characters are treated specially in slack text strings and must be escaped to HTML entities. This PR adds a template function that does the same.

Ref: https://api.slack.com/reference/surfaces/formatting#escaping